### PR TITLE
fix: replace hardcoded paths with relative paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ cd ~/.claude/skills/linear && npm install
 ### 2. Run Setup Check
 
 ```bash
-npx tsx ~/.claude/skills/linear/scripts/setup.ts
+npx tsx scripts/setup.ts
 ```
 
 This checks your configuration and tells you exactly what's missing.
@@ -50,7 +50,7 @@ source ~/.zshrc
 ### 4. Verify It Works
 
 ```bash
-npx tsx ~/.claude/skills/linear/scripts/linear-ops.ts whoami
+npx tsx scripts/linear-ops.ts whoami
 ```
 
 You should see your name and organization.

--- a/SKILL.md
+++ b/SKILL.md
@@ -103,7 +103,7 @@ cat .env
 Run the setup check to verify your configuration:
 
 ```bash
-npx tsx ~/.claude/skills/linear/scripts/setup.ts
+npx tsx scripts/setup.ts
 ```
 
 This will check:
@@ -136,7 +136,7 @@ echo 'LINEAR_API_KEY=lin_api_your_key_here' >> ~/.claude/.env
 Verify everything works:
 
 ```bash
-npx tsx ~/.claude/skills/linear/scripts/query.ts "query { viewer { name } }"
+npx tsx scripts/query.ts "query { viewer { name } }"
 ```
 
 You should see your name from Linear.
@@ -451,7 +451,7 @@ See **[api.md](api.md)** for complete documentation including:
 **Quick ad-hoc query:**
 
 ```bash
-npx tsx ~/.claude/skills/linear/scripts/query.ts "query { viewer { name } }"
+npx tsx scripts/query.ts "query { viewer { name } }"
 ```
 
 ## Projects & Initiatives

--- a/hooks/post-edit.sh
+++ b/hooks/post-edit.sh
@@ -78,7 +78,7 @@ all_issues=$(echo "$issue_refs $recent_issues" | tr ' ' '\n' | sort -u | grep -v
 # Output context for Claude (this gets added to the conversation)
 if [ -n "$all_issues" ]; then
   echo "[linear-sync] Changed: $filename | Issues: $all_issues"
-  echo "[linear-sync] Consider running: npx ts-node ~/.claude/skills/linear/scripts/sync.ts --issues ${all_issues// /,} --state Done"
+  echo "[linear-sync] Consider running: npx ts-node scripts/sync.ts --issues ${all_issues// /,} --state Done"
 fi
 
 exit 0

--- a/projects.md
+++ b/projects.md
@@ -256,7 +256,7 @@ mutation {
 **Example using query.ts:**
 
 ```bash
-npx tsx ~/.claude/skills/linear/scripts/query.ts 'mutation {
+npx tsx scripts/query.ts 'mutation {
   initiativeToProjectCreate(input: {
     initiativeId: "<initiative-uuid>",
     projectId: "<project-uuid>"

--- a/scripts/setup.ts
+++ b/scripts/setup.ts
@@ -103,7 +103,7 @@ async function checkSdkInstalled(): Promise<{ installed: boolean; issues: string
       issues: ['@linear/sdk not installed'],
       suggestions: [
         'Install the Linear SDK:',
-        '  cd ~/.claude/skills/linear && npm install @linear/sdk'
+        '  npm install @linear/sdk  # Run from the skill directory'
       ]
     };
   }

--- a/troubleshooting.md
+++ b/troubleshooting.md
@@ -58,30 +58,30 @@ A complete API wrapper with proper JSON escaping and error handling:
 
 ```bash
 # Create issue (replace <TEAM> with your team key, e.g., ENG, PROJ)
-node ~/.claude/skills/linear/scripts/linear-api.mjs create-issue \
+node scripts/linear-api.mjs create-issue \
   --team <TEAM> --title "New feature" --description "Details here" --priority 2
 
 # Update status (replace <TEAM>-123 with your issue identifier)
-node ~/.claude/skills/linear/scripts/linear-api.mjs update-status \
+node scripts/linear-api.mjs update-status \
   --issue <TEAM>-123 --status done
 
 # Add comment
-node ~/.claude/skills/linear/scripts/linear-api.mjs add-comment \
+node scripts/linear-api.mjs add-comment \
   --issue <TEAM>-123 --body "Fixed in PR #25"
 
 # Add project update
-node ~/.claude/skills/linear/scripts/linear-api.mjs add-project-update \
+node scripts/linear-api.mjs add-project-update \
   --project <PROJECT_UUID> --body "## Status Update\n\nProgress details..." --health onTrack
 
 # List issues
-node ~/.claude/skills/linear/scripts/linear-api.mjs list-issues \
+node scripts/linear-api.mjs list-issues \
   --team <TEAM> --status "In Progress" --limit 20
 
 # List labels
-node ~/.claude/skills/linear/scripts/linear-api.mjs list-labels --team <TEAM>
+node scripts/linear-api.mjs list-labels --team <TEAM>
 
 # Help
-node ~/.claude/skills/linear/scripts/linear-api.mjs help
+node scripts/linear-api.mjs help
 ```
 
 **Benefits over MCP:**
@@ -159,7 +159,7 @@ export LINEAR_API_KEY="lin_api_your_key_here"
 ### Test Connection
 
 ```bash
-npx tsx ~/.claude/skills/linear/scripts/query.ts "query { viewer { name } }"
+npx tsx scripts/query.ts "query { viewer { name } }"
 ```
 
 ### Check MCP Configuration


### PR DESCRIPTION
## Summary
- Replaced 16 hardcoded `~/.claude/skills/linear/scripts/` paths with relative `scripts/` equivalents across 6 files
- Fixes skill breakage when installed in project-local `.claude/skills/linear/` instead of global `~/.claude/skills/linear/`
- Preserved intentional absolute paths in installation instructions, hook configs, and changelog entries

## Files Changed
| File | Changes |
|------|---------|
| `SKILL.md` | 3 script invocation paths |
| `troubleshooting.md` | 8 script invocation paths |
| `projects.md` | 1 script invocation path |
| `README.md` | 2 script invocation paths (kept 4 install/hook paths) |
| `scripts/setup.ts` | 1 SDK install instruction |
| `hooks/post-edit.sh` | 1 sync suggestion path |

## Verification
- `grep ~/.claude/skills/linear/scripts/` returns 0 matches
- `npm run typecheck` passes
- `npm run lint` passes (0 errors, 11 pre-existing warnings)

## Test plan
- [ ] Install skill globally (`~/.claude/skills/linear/`) and verify commands in SKILL.md work
- [ ] Install skill locally (`.claude/skills/linear/`) and verify commands work
- [ ] Run `npx tsx scripts/setup.ts` from skill directory
- [ ] Run `npx tsx scripts/query.ts "query { viewer { name } }"` from skill directory

Closes #8
Linear: SMI-2424

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)