### PR TITLE
chore(release): bump to 2.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [2.2.3] - 2026-02-10
+
+### Changed
+- Added Varlock environment schema for secure secret management
+- Completed cross-skill hardcoded path audit across 9 repos (SMI-2426 through SMI-2435)
+- Updated README with changelog section
+
 ## [2.2.2](https://github.com/wrsmith108/linear-claude-skill/compare/v2.2.1...v2.2.2) (2026-02-10)
 
 

--- a/README.md
+++ b/README.md
@@ -348,6 +348,15 @@ Auto-suggest sync after code edits. Add to `.claude/settings.json`:
 
 See `sync.md` for complete patterns including AgentDB integration.
 
+## Changelog
+
+### 2.2.3 (2026-02-10)
+
+- Added Varlock environment schema for secure secret management
+- Completed cross-skill hardcoded path audit across 9 repos
+
+See [CHANGELOG.md](CHANGELOG.md) for full version history.
+
 ## Contributing
 
 Contributions welcome! Please submit issues and PRs to improve the skill.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-plugin-linear",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "type": "module",
   "description": "Claude Code skill for Linear issue, project, and team management with MCP integration",
   "keywords": [


### PR DESCRIPTION
## Summary
- Bump version from 2.2.2 to 2.2.3
- Add CHANGELOG entry for Varlock schema and cross-skill audit
- Add changelog section to README

Co-Authored-By: claude-flow <ruv@ruv.net>