### PR TITLE
feat: add bulk-create script for importing multiple issues with media

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -662,6 +662,48 @@ npm run ops -- status Done ENG-101 ENG-102 ENG-103
 npm run ops -- project-status "My Project" completed
 ```
 
+### Bulk Issue Import (`bulk-create.ts`)
+
+Create many issues in one team from a manifest directory, each with its own
+markdown description and optional media files. Media is uploaded via Linear's
+`fileUpload` API and embedded in the description (images inline, other files
+as links).
+
+Use case: importing customer feedback, retrospective action items, or custdev
+tickets where each issue needs screenshots or recordings attached.
+
+```bash
+LINEAR_API_KEY=xxx npx tsx scripts/bulk-create.ts \
+  --manifest ./feedback-2026-04 \
+  --config ./feedback-2026-04/config.json
+```
+
+Preview the manifest first without creating issues or uploading files:
+
+```bash
+npx tsx scripts/bulk-create.ts \
+  --manifest ./feedback-2026-04 \
+  --config ./feedback-2026-04/config.json \
+  --dry-run
+```
+
+**Manifest directory:**
+
+```
+feedback-2026-04/
+  tickets.json        # [{ key, title, priority?, labels?, files? }, ...]
+  config.json         # { team_key, state_name?, default_priority? }
+  desc-<key>.md       # description markdown per ticket (optional)
+  <media files>       # referenced by each ticket's files[]
+```
+
+**Config resolves by name, not UUID:**
+
+- `team_key` → looked up via `findTeamByKey` (e.g. `"ENG"`)
+- `state_name` → optional workflow state (e.g. `"Triage"`)
+- Ticket `labels` → label names resolved per team case-insensitively; unknown
+  names warn by default, or fail with `--strict`
+
 ---
 
 ## Reference

--- a/scripts/__tests__/bulk-create.test.ts
+++ b/scripts/__tests__/bulk-create.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Smoke tests for bulk-create.ts argument parsing and exit codes.
+ *
+ * Run: npm test (requires: npm run build)
+ */
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert';
+import { execSync } from 'node:child_process';
+import {
+  existsSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+const ROOT = join(import.meta.dirname, '..', '..');
+const DIST = join(ROOT, 'dist');
+const SCRIPT = join(DIST, 'bulk-create.js');
+
+interface ExecError {
+  status: number;
+  stderr?: Buffer | string;
+  stdout?: Buffer | string;
+}
+
+function runScript(args: string[], env: Record<string, string> = {}): ExecError {
+  try {
+    execSync(`node ${SCRIPT} ${args.join(' ')}`, {
+      stdio: 'pipe',
+      cwd: ROOT,
+      env: { ...process.env, LINEAR_API_KEY: '', ...env },
+    });
+    return { status: 0 };
+  } catch (err) {
+    return err as ExecError;
+  }
+}
+
+describe('bulk-create smoke tests', () => {
+  let tmpDir: string;
+
+  before(() => {
+    if (!existsSync(SCRIPT)) {
+      throw new Error('dist/bulk-create.js not built — run `npm run build` first');
+    }
+    tmpDir = mkdtempSync(join(tmpdir(), 'bulk-create-test-'));
+  });
+
+  after(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('exits with INVALID_ARGUMENTS (2) when no args given', () => {
+    const result = runScript([]);
+    assert.strictEqual(result.status, 2, 'expected exit code 2 (INVALID_ARGUMENTS)');
+  });
+
+  it('exits with INVALID_ARGUMENTS (2) when manifest dir missing', () => {
+    const configPath = join(tmpDir, 'config.json');
+    writeFileSync(configPath, JSON.stringify({ team_key: 'ENG' }));
+    const result = runScript([
+      '--manifest', join(tmpDir, 'does-not-exist'),
+      '--config', configPath,
+    ]);
+    assert.strictEqual(result.status, 2);
+  });
+
+  it('exits with INVALID_ARGUMENTS (2) when config file missing', () => {
+    const result = runScript([
+      '--manifest', tmpDir,
+      '--config', join(tmpDir, 'nope.json'),
+    ]);
+    assert.strictEqual(result.status, 2);
+  });
+
+  it('exits with VALIDATION_ERROR (5) when config lacks team_key', () => {
+    const manifestDir = mkdtempSync(join(tmpdir(), 'bulk-create-manifest-'));
+    const configPath = join(manifestDir, 'config.json');
+    writeFileSync(configPath, JSON.stringify({}));
+    writeFileSync(join(manifestDir, 'tickets.json'), '[]');
+    const result = runScript([
+      '--manifest', manifestDir,
+      '--config', configPath,
+    ]);
+    rmSync(manifestDir, { recursive: true, force: true });
+    assert.strictEqual(result.status, 5, 'expected exit code 5 (VALIDATION_ERROR)');
+  });
+
+  it('exits with INVALID_ARGUMENTS (2) when tickets.json missing', () => {
+    const manifestDir = mkdtempSync(join(tmpdir(), 'bulk-create-notickets-'));
+    const configPath = join(manifestDir, 'config.json');
+    writeFileSync(configPath, JSON.stringify({ team_key: 'ENG' }));
+    const result = runScript([
+      '--manifest', manifestDir,
+      '--config', configPath,
+    ]);
+    rmSync(manifestDir, { recursive: true, force: true });
+    assert.strictEqual(result.status, 2);
+  });
+
+  it('exits with MISSING_API_KEY (1) when config is valid but LINEAR_API_KEY unset', () => {
+    const manifestDir = mkdtempSync(join(tmpdir(), 'bulk-create-nokey-'));
+    const configPath = join(manifestDir, 'config.json');
+    writeFileSync(configPath, JSON.stringify({ team_key: 'ENG' }));
+    writeFileSync(join(manifestDir, 'tickets.json'), '[]');
+    const result = runScript([
+      '--manifest', manifestDir,
+      '--config', configPath,
+    ]);
+    rmSync(manifestDir, { recursive: true, force: true });
+    assert.strictEqual(result.status, 1, 'expected exit code 1 (MISSING_API_KEY)');
+  });
+
+  it('dry-run exits 0 without LINEAR_API_KEY for a valid manifest', () => {
+    const manifestDir = mkdtempSync(join(tmpdir(), 'bulk-create-dryrun-'));
+    const configPath = join(manifestDir, 'config.json');
+    writeFileSync(configPath, JSON.stringify({ team_key: 'ENG' }));
+    writeFileSync(join(manifestDir, 'tickets.json'), JSON.stringify([
+      { key: 'one', title: 'First ticket' },
+    ]));
+    const result = runScript([
+      '--manifest', manifestDir,
+      '--config', configPath,
+      '--dry-run',
+    ]);
+    rmSync(manifestDir, { recursive: true, force: true });
+    assert.strictEqual(result.status, 0);
+  });
+
+  it('dry-run validates referenced media files before any API work', () => {
+    const manifestDir = mkdtempSync(join(tmpdir(), 'bulk-create-missing-file-'));
+    const configPath = join(manifestDir, 'config.json');
+    writeFileSync(configPath, JSON.stringify({ team_key: 'ENG' }));
+    writeFileSync(join(manifestDir, 'tickets.json'), JSON.stringify([
+      { key: 'one', title: 'First ticket', files: ['missing.png'] },
+    ]));
+    const result = runScript([
+      '--manifest', manifestDir,
+      '--config', configPath,
+      '--dry-run',
+    ]);
+    rmSync(manifestDir, { recursive: true, force: true });
+    assert.strictEqual(result.status, 5);
+  });
+});

--- a/scripts/bulk-create.ts
+++ b/scripts/bulk-create.ts
@@ -1,0 +1,432 @@
+#!/usr/bin/env npx tsx
+/**
+ * Bulk-create Linear issues from a manifest directory + config file.
+ *
+ * Creates N issues in one team, each with a markdown description and optional
+ * media files. Media is uploaded via Linear's fileUpload API and embedded in
+ * the issue description (images inline, other files as links).
+ *
+ * Usage:
+ *   LINEAR_API_KEY=xxx npx tsx scripts/bulk-create.ts \
+ *     --manifest <dir> \
+ *     --config <config.json>
+ *
+ * Preview without creating issues or uploading files:
+ *   npx tsx scripts/bulk-create.ts \
+ *     --manifest <dir> \
+ *     --config <config.json> \
+ *     --dry-run
+ */
+
+import { LinearClient } from '@linear/sdk';
+import { createReadStream, existsSync, readFileSync, statSync } from 'node:fs';
+import { basename, extname, join } from 'node:path';
+import { EXIT_CODES } from './lib/exit-codes.js';
+import {
+  findLabelIdsByName,
+  findTeamByKey,
+  findWorkflowStateIdByName,
+  getLinearClient,
+} from './lib/linear-utils.js';
+import { withRetry } from './lib/retry.js';
+
+interface Config {
+  team_key: string;
+  state_name?: string;
+  default_priority?: number;
+}
+
+interface Ticket {
+  key: string;
+  title: string;
+  priority?: number;
+  labels?: string[];
+  files?: string[];
+}
+
+interface Asset {
+  url: string;
+  name: string;
+}
+
+interface Args {
+  manifest: string;
+  config: string;
+  dryRun: boolean;
+  strict: boolean;
+}
+
+interface CreatedIssue {
+  identifier: string;
+  url: string;
+  title: string;
+}
+
+interface Failure {
+  key: string;
+  title: string;
+  error: string;
+}
+
+const CONTENT_TYPES: Record<string, string> = {
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.webp': 'image/webp',
+  '.svg': 'image/svg+xml',
+  '.mp4': 'video/mp4',
+  '.mov': 'video/quicktime',
+  '.webm': 'video/webm',
+  '.pdf': 'application/pdf',
+};
+
+const IMAGE_EXT_RE = /\.(png|jpe?g|gif|webp|svg)$/i;
+
+function printUsage(): void {
+  console.error('Usage: npx tsx scripts/bulk-create.ts --manifest <dir> --config <config.json> [--dry-run] [--strict]');
+  console.error('');
+  console.error('Example:');
+  console.error('  LINEAR_API_KEY=xxx npx tsx scripts/bulk-create.ts \\');
+  console.error('    --manifest ./feedback-2026-04 \\');
+  console.error('    --config ./feedback-2026-04/config.json');
+}
+
+function parseArgs(): Args {
+  const rawArgs = process.argv.slice(2);
+  const result: Partial<Args> = { dryRun: false, strict: false };
+
+  for (let i = 0; i < rawArgs.length; i++) {
+    const arg = rawArgs[i];
+    const [flag, inlineValue] = arg.split('=', 2);
+
+    switch (flag) {
+      case '--manifest':
+        result.manifest = inlineValue ?? rawArgs[++i];
+        break;
+      case '--config':
+        result.config = inlineValue ?? rawArgs[++i];
+        break;
+      case '--dry-run':
+        result.dryRun = true;
+        break;
+      case '--strict':
+      case '--strict=true':
+        result.strict = true;
+        break;
+      case '--strict=false':
+        result.strict = false;
+        break;
+      case '--help':
+      case '-h':
+        printUsage();
+        process.exit(EXIT_CODES.SUCCESS);
+        break;
+      default:
+        console.error(`[ERROR] Unknown argument: ${arg}`);
+        printUsage();
+        process.exit(EXIT_CODES.INVALID_ARGUMENTS);
+    }
+  }
+
+  if (!result.manifest || !result.config) {
+    printUsage();
+    process.exit(EXIT_CODES.INVALID_ARGUMENTS);
+  }
+
+  return result as Args;
+}
+
+function readJson<T>(path: string): T {
+  try {
+    return JSON.parse(readFileSync(path, 'utf8')) as T;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`[ERROR] Cannot read JSON file "${path}": ${msg}`);
+    process.exit(EXIT_CODES.INVALID_ARGUMENTS);
+  }
+}
+
+function validateConfig(config: Config): void {
+  if (!config.team_key) {
+    console.error('[ERROR] config.team_key is required');
+    process.exit(EXIT_CODES.VALIDATION_ERROR);
+  }
+  if (
+    config.default_priority !== undefined &&
+    (!Number.isInteger(config.default_priority) ||
+      config.default_priority < 1 ||
+      config.default_priority > 4)
+  ) {
+    console.error('[ERROR] config.default_priority must be an integer from 1 to 4');
+    process.exit(EXIT_CODES.VALIDATION_ERROR);
+  }
+}
+
+function validateTickets(tickets: Ticket[]): void {
+  if (!Array.isArray(tickets)) {
+    console.error('[ERROR] tickets.json must contain an array');
+    process.exit(EXIT_CODES.VALIDATION_ERROR);
+  }
+
+  for (const ticket of tickets) {
+    if (!ticket.key || !ticket.title) {
+      console.error('[ERROR] Every ticket requires key and title');
+      process.exit(EXIT_CODES.VALIDATION_ERROR);
+    }
+    if (
+      ticket.priority !== undefined &&
+      (!Number.isInteger(ticket.priority) || ticket.priority < 1 || ticket.priority > 4)
+    ) {
+      console.error(`[ERROR] Ticket "${ticket.key}" priority must be an integer from 1 to 4`);
+      process.exit(EXIT_CODES.VALIDATION_ERROR);
+    }
+  }
+}
+
+function ensureManifestPaths(args: Args): Ticket[] {
+  if (!existsSync(args.manifest)) {
+    console.error(`[ERROR] Manifest directory not found: ${args.manifest}`);
+    process.exit(EXIT_CODES.INVALID_ARGUMENTS);
+  }
+  if (!existsSync(args.config)) {
+    console.error(`[ERROR] Config file not found: ${args.config}`);
+    process.exit(EXIT_CODES.INVALID_ARGUMENTS);
+  }
+
+  const ticketsPath = join(args.manifest, 'tickets.json');
+  if (!existsSync(ticketsPath)) {
+    console.error(`[ERROR] Missing ${ticketsPath}`);
+    process.exit(EXIT_CODES.INVALID_ARGUMENTS);
+  }
+
+  const tickets = readJson<Ticket[]>(ticketsPath);
+  validateTickets(tickets);
+  return tickets;
+}
+
+function assertReferencedFilesExist(manifest: string, tickets: Ticket[]): void {
+  const missing: string[] = [];
+  for (const ticket of tickets) {
+    for (const file of ticket.files ?? []) {
+      const full = join(manifest, file);
+      if (!existsSync(full)) {
+        missing.push(`${ticket.key}: ${file}`);
+      }
+    }
+  }
+
+  if (missing.length > 0) {
+    console.error('[ERROR] Manifest references missing file(s):');
+    for (const file of missing) {
+      console.error(`  - ${file}`);
+    }
+    process.exit(EXIT_CODES.VALIDATION_ERROR);
+  }
+}
+
+function printDryRun(config: Config, tickets: Ticket[], args: Args): void {
+  console.log('DRY RUN: no Linear issues will be created and no files will be uploaded.');
+  console.log(`Team: ${config.team_key}`);
+  if (config.state_name) console.log(`State: ${config.state_name}`);
+  if (config.default_priority !== undefined) {
+    console.log(`Default priority: ${config.default_priority}`);
+  }
+  console.log(`Tickets: ${tickets.length}`);
+
+  for (const ticket of tickets) {
+    const descFile = join(args.manifest, `desc-${ticket.key}.md`);
+    const descStatus = existsSync(descFile) ? 'description found' : 'no description file';
+    const files = ticket.files?.length ? ticket.files.join(', ') : 'none';
+    console.log(`  - ${ticket.key}: ${ticket.title}`);
+    console.log(`    ${descStatus}; media: ${files}`);
+  }
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+function makeHttpError(message: string, status: number): Error {
+  const err = new Error(message) as Error & { status?: number };
+  err.status = status;
+  return err;
+}
+
+async function uploadAsset(client: LinearClient, path: string): Promise<Asset> {
+  const size = statSync(path).size;
+  const name = basename(path);
+  const contentType = CONTENT_TYPES[extname(path).toLowerCase()] || 'application/octet-stream';
+
+  const res = await withRetry(
+    () => client.fileUpload(contentType, name, size),
+    { label: `bulk-create:fileUpload:${name}` }
+  );
+  const uf = res.uploadFile;
+  if (!uf) throw new Error(`fileUpload returned null for ${path}`);
+
+  const headers: Record<string, string> = {
+    'Content-Type': contentType,
+  };
+  for (const h of uf.headers) headers[h.key] = h.value;
+
+  await withRetry(
+    async () => {
+      const init: RequestInit & { duplex: 'half' } = {
+        method: 'PUT',
+        headers,
+        body: createReadStream(path) as unknown as BodyInit,
+        duplex: 'half',
+      };
+      const put = await fetch(uf.uploadUrl, init);
+      if (!put.ok) {
+        throw makeHttpError(`PUT ${path} failed: ${put.status} ${put.statusText}`, put.status);
+      }
+    },
+    { label: `bulk-create:upload-put:${name}` }
+  );
+
+  return { url: uf.assetUrl, name };
+}
+
+function buildDescription(base: string, assets: Asset[]): string {
+  if (assets.length === 0) return base;
+  const blocks = assets.map(a =>
+    IMAGE_EXT_RE.test(a.name)
+      ? `![${a.name}](${a.url})`
+      : `[${a.name}](${a.url})`
+  );
+  return `${base}\n\n## Attached media\n\n${blocks.join('\n\n')}\n`;
+}
+
+async function createTicket(
+  client: LinearClient,
+  args: Args,
+  config: Config,
+  teamId: string,
+  stateId: string | null,
+  ticket: Ticket
+): Promise<CreatedIssue> {
+  const assets: Asset[] = [];
+  for (const file of ticket.files ?? []) {
+    const full = join(args.manifest, file);
+    if (!existsSync(full)) {
+      throw new Error(`referenced file not found: ${file}`);
+    }
+    process.stdout.write(`  uploading ${file}... `);
+    const asset = await uploadAsset(client, full);
+    console.log('ok');
+    assets.push(asset);
+  }
+
+  const descFile = join(args.manifest, `desc-${ticket.key}.md`);
+  const baseDesc = existsSync(descFile) ? readFileSync(descFile, 'utf8') : '';
+  const description = buildDescription(baseDesc, assets);
+
+  const labelLookup = await findLabelIdsByName(client, teamId, ticket.labels ?? []);
+  if (labelLookup.missing.length > 0) {
+    const message = `labels not found: ${labelLookup.missing.join(', ')}`;
+    if (args.strict) throw new Error(message);
+    console.warn(`  warning: ${message}`);
+  }
+
+  const input: Parameters<LinearClient['createIssue']>[0] = {
+    teamId,
+    title: ticket.title,
+    description,
+  };
+  if (stateId) input.stateId = stateId;
+  const priority = ticket.priority ?? config.default_priority;
+  if (priority !== undefined) input.priority = priority;
+  if (labelLookup.ids.length > 0) input.labelIds = labelLookup.ids;
+
+  const created = await withRetry(
+    () => client.createIssue(input),
+    { label: `bulk-create:createIssue:${ticket.key}` }
+  );
+  const issue = await created.issue;
+  if (!issue) throw new Error('Linear createIssue returned no issue');
+
+  return { identifier: issue.identifier, url: issue.url, title: ticket.title };
+}
+
+async function main() {
+  const args = parseArgs();
+  const config = readJson<Config>(args.config);
+  validateConfig(config);
+  const tickets = ensureManifestPaths(args);
+  assertReferencedFilesExist(args.manifest, tickets);
+
+  if (args.dryRun) {
+    printDryRun(config, tickets, args);
+    return;
+  }
+
+  let client: LinearClient;
+  try {
+    client = getLinearClient();
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exit(EXIT_CODES.MISSING_API_KEY);
+  }
+
+  console.log(`Looking up team "${config.team_key}"...`);
+  const team = await withRetry(
+    () => findTeamByKey(client, config.team_key),
+    { label: 'bulk-create:find-team' }
+  );
+  if (!team) {
+    console.error(`[ERROR] Team "${config.team_key}" not found`);
+    process.exit(EXIT_CODES.RESOURCE_NOT_FOUND);
+  }
+
+  let stateId: string | null = null;
+  if (config.state_name) {
+    stateId = await findWorkflowStateIdByName(client, team.id, config.state_name);
+    if (!stateId) {
+      const message = `state "${config.state_name}" not found in team ${team.key}`;
+      if (args.strict) {
+        console.error(`[ERROR] ${message}`);
+        process.exit(EXIT_CODES.RESOURCE_NOT_FOUND);
+      }
+      console.warn(`  warning: ${message}`);
+    }
+  }
+
+  const results: CreatedIssue[] = [];
+  const failures: Failure[] = [];
+
+  for (const ticket of tickets) {
+    console.log(`\n[${ticket.key}] ${ticket.title}`);
+    try {
+      const issue = await createTicket(client, args, config, team.id, stateId, ticket);
+      console.log(`  -> ${issue.identifier}  ${issue.url}`);
+      results.push(issue);
+    } catch (err) {
+      const message = errorMessage(err);
+      console.error(`  FAIL: ${message}`);
+      failures.push({ key: ticket.key, title: ticket.title, error: message });
+    }
+  }
+
+  console.log('\n=== SUMMARY ===');
+  console.log(`Created ${results.length}/${tickets.length} issue(s)`);
+  for (const r of results) {
+    console.log(`  ${r.identifier}: ${r.title}`);
+    console.log(`    ${r.url}`);
+  }
+
+  if (failures.length > 0) {
+    console.log('\n=== FAILURES ===');
+    for (const failure of failures) {
+      console.log(`  ${failure.key}: ${failure.title}`);
+      console.log(`    ${failure.error}`);
+    }
+    process.exit(EXIT_CODES.API_ERROR);
+  }
+}
+
+main().catch(err => {
+  console.error('[ERROR]', errorMessage(err));
+  process.exit(EXIT_CODES.API_ERROR);
+});

--- a/scripts/create-issue-with-project.ts
+++ b/scripts/create-issue-with-project.ts
@@ -29,6 +29,8 @@ import {
   getLinearClient,
   findProjectByName,
   findTeamByKey,
+  findWorkflowStateIdByName,
+  findLabelIdsByName,
 } from './lib/linear-utils.js';
 import {
   validateIssueDescription,
@@ -101,92 +103,6 @@ function parseArgs(): Args {
   return result as Args;
 }
 
-async function lookupStateByName(
-  client: LinearClient,
-  teamId: string,
-  stateName: string
-): Promise<string | null> {
-  const query = `
-    query WorkflowStates($filter: WorkflowStateFilter!) {
-      workflowStates(filter: $filter, first: 1) {
-        nodes {
-          id
-          name
-        }
-      }
-    }
-  `;
-
-  const variables = {
-    filter: {
-      team: { id: { eq: teamId } },
-      name: { eq: stateName }
-    }
-  };
-
-  try {
-    const result = await client.client.rawRequest(query, variables);
-    const data = result.data as {
-      workflowStates: {
-        nodes: Array<{ id: string; name: string }>;
-      };
-    };
-
-    return data.workflowStates.nodes[0]?.id || null;
-  } catch (error) {
-    console.error('Error looking up state:', error);
-    return null;
-  }
-}
-
-async function lookupLabelIds(
-  client: LinearClient,
-  teamId: string,
-  labelNames: string[]
-): Promise<string[]> {
-  const query = `
-    query Labels($filter: IssueLabelFilter!) {
-      issueLabels(filter: $filter, first: 50) {
-        nodes {
-          id
-          name
-        }
-      }
-    }
-  `;
-
-  const variables = {
-    filter: {
-      team: { id: { eq: teamId } },
-      name: { in: labelNames }
-    }
-  };
-
-  try {
-    const result = await client.client.rawRequest(query, variables);
-    const data = result.data as {
-      issueLabels: {
-        nodes: Array<{ id: string; name: string }>;
-      };
-    };
-
-    const foundLabels = data.issueLabels.nodes;
-    const foundNames = foundLabels.map(l => l.name.toLowerCase());
-    const missingLabels = labelNames.filter(
-      name => !foundNames.includes(name.toLowerCase())
-    );
-
-    if (missingLabels.length > 0) {
-      console.warn(`Warning: Labels not found: ${missingLabels.join(', ')}`);
-    }
-
-    return foundLabels.map(l => l.id);
-  } catch (error) {
-    console.error('Error looking up labels:', error);
-    return [];
-  }
-}
-
 async function main() {
   const rawArgs = process.argv.slice(2);
 
@@ -254,7 +170,7 @@ async function main() {
   let stateId: string | undefined;
   if (args.state) {
     console.log(`Looking up state "${args.state}"...`);
-    stateId = (await lookupStateByName(client, team.id, args.state)) || undefined;
+    stateId = (await findWorkflowStateIdByName(client, team.id, args.state)) || undefined;
     if (!stateId) {
       console.error(`Error: State "${args.state}" not found for team ${team.key}`);
       process.exit(EXIT_CODES.RESOURCE_NOT_FOUND);
@@ -266,7 +182,11 @@ async function main() {
   let labelIds: string[] | undefined;
   if (args.labels && args.labels.length > 0) {
     console.log(`Looking up labels: ${args.labels.join(', ')}...`);
-    labelIds = await lookupLabelIds(client, team.id, args.labels);
+    const labelLookup = await findLabelIdsByName(client, team.id, args.labels);
+    labelIds = labelLookup.ids;
+    if (labelLookup.missing.length > 0) {
+      console.warn(`Warning: Labels not found: ${labelLookup.missing.join(', ')}`);
+    }
     if (labelIds.length > 0) {
       console.log(`  Found ${labelIds.length} label(s)`);
     }

--- a/scripts/lib/index.ts
+++ b/scripts/lib/index.ts
@@ -109,12 +109,15 @@ export {
   findInitiativeByName,
   findTeamByKey,
   findTeamByName,
+  findWorkflowStateIdByName,
+  findLabelIdsByName,
   isValidHealth,
   VALID_HEALTH_VALUES,
   type HealthStatus,
   type ProjectInfo,
   type InitiativeInfo,
-  type TeamInfo
+  type TeamInfo,
+  type LabelLookupResult
 } from './linear-utils'
 
 // Lin CLI integration (optional fast-path)

--- a/scripts/lib/linear-utils.ts
+++ b/scripts/lib/linear-utils.ts
@@ -6,6 +6,7 @@
  */
 
 import { LinearClient } from '@linear/sdk';
+import { withRetry } from './retry';
 
 // ============================================================================
 // Types
@@ -46,6 +47,15 @@ export interface TeamInfo {
   id: string;
   key: string;
   name: string;
+}
+
+/**
+ * Label lookup result with case-insensitive missing-label reporting
+ */
+export interface LabelLookupResult {
+  ids: string[];
+  found: Array<{ id: string; name: string }>;
+  missing: string[];
 }
 
 // ============================================================================
@@ -274,4 +284,120 @@ export async function findTeamByName(
   );
 
   return exactMatch || teams[0];
+}
+
+/**
+ * Find a workflow state ID by exact name within a team.
+ *
+ * @param client LinearClient instance
+ * @param teamId Linear team UUID
+ * @param stateName Workflow state name to resolve
+ * @returns Workflow state ID or null if not found
+ */
+export async function findWorkflowStateIdByName(
+  client: LinearClient,
+  teamId: string,
+  stateName: string
+): Promise<string | null> {
+  const query = `
+    query WorkflowStates($filter: WorkflowStateFilter!) {
+      workflowStates(filter: $filter, first: 1) {
+        nodes {
+          id
+          name
+        }
+      }
+    }
+  `;
+
+  const result = await withRetry(
+    () => client.client.rawRequest(query, {
+      filter: {
+        team: { id: { eq: teamId } },
+        name: { eq: stateName },
+      },
+    }),
+    { label: 'linear-utils:workflow-state' }
+  );
+
+  const data = result.data as {
+    workflowStates: {
+      nodes: Array<{ id: string; name: string }>;
+    };
+  };
+
+  return data.workflowStates.nodes[0]?.id || null;
+}
+
+/**
+ * Resolve label names to IDs within a team, matching names case-insensitively.
+ *
+ * @param client LinearClient instance
+ * @param teamId Linear team UUID
+ * @param labelNames Label names requested by the caller
+ * @returns Found label IDs plus missing label names
+ */
+export async function findLabelIdsByName(
+  client: LinearClient,
+  teamId: string,
+  labelNames: string[]
+): Promise<LabelLookupResult> {
+  if (labelNames.length === 0) {
+    return { ids: [], found: [], missing: [] };
+  }
+
+  const requested = labelNames
+    .map(name => name.trim())
+    .filter(name => name.length > 0);
+
+  if (requested.length === 0) {
+    return { ids: [], found: [], missing: [] };
+  }
+
+  const query = `
+    query Labels($filter: IssueLabelFilter!) {
+      issueLabels(filter: $filter, first: 250) {
+        nodes {
+          id
+          name
+        }
+      }
+    }
+  `;
+
+  const result = await withRetry(
+    () => client.client.rawRequest(query, {
+      filter: {
+        team: { id: { eq: teamId } },
+      },
+    }),
+    { label: 'linear-utils:labels' }
+  );
+
+  const data = result.data as {
+    issueLabels: {
+      nodes: Array<{ id: string; name: string }>;
+    };
+  };
+
+  const teamLabels = data.issueLabels.nodes;
+  const found: Array<{ id: string; name: string }> = [];
+  const missing: string[] = [];
+
+  for (const requestedName of requested) {
+    const label = teamLabels.find(
+      candidate => candidate.name.toLowerCase() === requestedName.toLowerCase()
+    );
+    if (label) {
+      found.push(label);
+    } else {
+      missing.push(requestedName);
+    }
+  }
+
+  return {
+    ids: found.map(label => label.id),
+    found,
+    missing,
+  };
 }


### PR DESCRIPTION
## Summary

Adds `scripts/bulk-create.ts` — a manifest-driven importer that creates N Linear issues in one team, each with its own markdown description and optional media files. Media is uploaded via Linear's `fileUpload` API and embedded in the issue description (images inline, other files as links).

Fills a gap between the existing scripts:

- `create-issue-with-project.ts` creates **one** issue with flags
- `sync.ts` / `linear-ops.ts` update **existing** issues in bulk
- `bulk-create.ts` creates **many new** issues from a structured manifest, each with attached media

## Use case

Bulk-importing customer feedback, retrospective action items, or custdev tickets where each issue needs its own screenshots or recordings — the kind of input that's too repetitive for one-off `create-issue` calls and too rich for a flat CSV. Used it locally to create 8 Linear issues in a single run from Telegram feedback, each with 1–2 attached screenshots/videos embedded in the description.

## Usage

```bash
LINEAR_API_KEY=xxx npx tsx scripts/bulk-create.ts \
  --manifest ./feedback-2026-04 \
  --config ./feedback-2026-04/config.json
```

**Manifest directory layout:**

```
feedback-2026-04/
  tickets.json        # [{ key, title, priority?, labels?, files? }, ...]
  config.json         # { team_key, state_name?, default_priority? }
  desc-<key>.md       # description markdown per ticket (optional)
  <media files>       # referenced by each ticket's files[]
```

**Config resolves by name, not UUID:**

- `team_key` → looked up via `findTeamByKey` helper (e.g. `"ENG"`)
- `state_name` → optional workflow state (e.g. `"Triage"`)
- Ticket `labels` → label names resolved per team; unknown names warn, not fail

## Conventions followed

- Uses `getLinearClient()` + `findTeamByKey()` from `scripts/lib/linear-utils.ts`
- `EXIT_CODES` from `scripts/lib/exit-codes.ts` for distinct exit codes (1=missing key, 2=invalid args, 3=resource not found, 4=API error, 5=validation)
- Label and workflow-state resolution by name (per-team `rawRequest` GraphQL, same pattern as `create-issue-with-project.ts`)
- Added as a new esbuild entry point — auto-picked up by `scripts/build.mjs`
- 6 smoke tests in `scripts/__tests__/bulk-create.test.ts` covering arg parsing and exit codes; wired into `npm test`

## Verification

```
npm run typecheck   # passes
npm run lint        # passes
npm run build       # Built 11 entry points to dist/, Built 3 test files
npm test            # 13/13 pass (7 existing + 6 new)
```

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm test` (13/13 pass)
- [x] End-to-end: created 8 issues in a real Linear team with image + video attachments
