### PR TITLE
v3.1.0 AC-enforcement follow-ups: version parity + exit-code harmonization

### DIFF
--- a/scripts/__tests__/smoke.test.ts
+++ b/scripts/__tests__/smoke.test.ts
@@ -101,6 +101,24 @@ describe('smoke tests', () => {
     );
   });
 
+  it('CLI create-issue exits 5 (VALIDATION_ERROR) on strict AC failure', () => {
+    // Validation runs BEFORE the API call, so no LINEAR_API_KEY is needed.
+    try {
+      execSync(
+        `node ${join(DIST, 'linear-ops.js')} create-issue "X" "Y" "too short"`,
+        { stdio: 'pipe', cwd: ROOT, env: { ...process.env, LINEAR_API_KEY: '' } }
+      );
+      assert.fail('Expected create-issue to exit non-0 on invalid description');
+    } catch (err: unknown) {
+      const error = err as { status: number };
+      assert.strictEqual(
+        error.status,
+        5,
+        `Expected exit 5 (VALIDATION_ERROR), got ${error.status}`
+      );
+    }
+  });
+
   it('SKILL.md frontmatter version matches package.json version', () => {
     const skill = readFileSync(join(ROOT, 'SKILL.md'), 'utf8');
     const fm = skill.match(/^---\n([\s\S]*?)\n---\n/);

--- a/scripts/__tests__/smoke.test.ts
+++ b/scripts/__tests__/smoke.test.ts
@@ -100,4 +100,21 @@ describe('smoke tests', () => {
       'dist/linear-ops.js should reference @linear/sdk as an external import'
     );
   });
+
+  it('SKILL.md frontmatter version matches package.json version', () => {
+    const skill = readFileSync(join(ROOT, 'SKILL.md'), 'utf8');
+    const fm = skill.match(/^---\n([\s\S]*?)\n---\n/);
+    assert.ok(fm, 'SKILL.md must start with YAML frontmatter');
+    const versionLine = fm[1].match(/^version:\s*(.+)$/m);
+    assert.ok(versionLine, 'SKILL.md frontmatter must contain a version: line');
+    const skillVersion = versionLine[1].trim();
+    const pkgVersion = JSON.parse(
+      readFileSync(join(ROOT, 'package.json'), 'utf8')
+    ).version;
+    assert.strictEqual(
+      skillVersion,
+      pkgVersion,
+      `SKILL.md version (${skillVersion}) must equal package.json version (${pkgVersion}). Run 'node scripts/sync-skill-version.mjs ${pkgVersion}' to fix.`
+    );
+  });
 });

--- a/scripts/linear-ops.ts
+++ b/scripts/linear-ops.ts
@@ -132,7 +132,7 @@ const commands: Record<string, (...args: string[]) => Promise<void>> = {
       const output = formatDescriptionValidationResult(descResult);
       if (!descResult.valid && strict) {
         console.error(output);
-        process.exit(1);
+        process.exit(EXIT_CODES.VALIDATION_ERROR);
       } else if (!descResult.valid) {
         console.warn('[WARN] Description validation downgraded (strict mode off):');
         console.warn(output);
@@ -1007,7 +1007,7 @@ const commands: Record<string, (...args: string[]) => Promise<void>> = {
       const output = formatDescriptionValidationResult(descResult);
       if (!descResult.valid && strict) {
         console.error(output);
-        process.exit(1);
+        process.exit(EXIT_CODES.VALIDATION_ERROR);
       } else if (!descResult.valid) {
         console.warn('[WARN] Description validation downgraded (strict mode off):');
         console.warn(output);


### PR DESCRIPTION
## Summary

Two small follow-ups deferred from the v3.1.0 release, bundled because they're adjacent and cheap to review together.

- **SMI-4326** — smoke test asserting `SKILL.md` frontmatter `version:` equals `package.json` version. Guards against drift if `scripts/sync-skill-version.mjs` ever breaks mid-release and someone hand-edits the file.
- **SMI-4327** — `create-issue` and `create-sub-issue` now exit `5` (`EXIT_CODES.VALIDATION_ERROR`) on strict AC-validation failure, matching `create-issue-with-project` and `validate-description`. Previously exited `1`, which collided with `MISSING_API_KEY`.

## Behavior change (SMI-4327)

Scripts checking `$? == 1` to detect AC violations will now see `$? == 5`. No known external consumers — the skill's audience is Claude Code itself. Included in `refactor:` commit type (no major bump).

## Test plan
- [x] `npm run build && npm test` — 49/49 pass (47 existing + 2 new)
- [x] Manual: `node dist/linear-ops.js create-issue "X" "Y" "too short"` → exit 5
- [x] Manual: `node dist/linear-ops.js create-sub-issue SMI-1 "Y" "too short"` → exit 5
- [x] New parity test passes on current tree (both `3.1.0`)
- [x] Verified parity test would fail on drift (manual sed + revert during plan)

Closes SMI-4326, SMI-4327.

🤖 Generated with [Claude Code](https://claude.com/claude-code)