### PR TITLE
feat(labels): retry/backoff wrapper for 429s on label fetcher (SMI-4346)

### DIFF
--- a/scripts/__tests__/retry.test.ts
+++ b/scripts/__tests__/retry.test.ts
@@ -1,0 +1,317 @@
+/**
+ * Tests for withRetry helper in scripts/lib/retry.ts
+ *
+ * Run: node --test scripts/__tests__/retry.test.ts
+ */
+
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert';
+
+import {
+  withRetry,
+  extractStatusCode,
+  extractRetryAfterMs,
+  isRetryableStatus,
+  computeBackoffMs
+} from '../lib/retry.ts';
+
+// Silent sleep — tests never actually wait.
+const noSleep = async () => {};
+const noLog = () => {};
+
+function makeHttpError(status: number, extra: Record<string, unknown> = {}) {
+  const err = new Error(`HTTP ${status}`) as Error & Record<string, unknown>;
+  err.status = status;
+  Object.assign(err, extra);
+  return err;
+}
+
+describe('extractStatusCode', () => {
+  it('reads status from err.status', () => {
+    assert.strictEqual(extractStatusCode({ status: 429 }), 429);
+  });
+
+  it('reads status from err.statusCode', () => {
+    assert.strictEqual(extractStatusCode({ statusCode: 503 }), 503);
+  });
+
+  it('reads status from err.response.status', () => {
+    assert.strictEqual(extractStatusCode({ response: { status: 502 } }), 502);
+  });
+
+  it('parses status out of message when no field present', () => {
+    assert.strictEqual(
+      extractStatusCode(new Error('Request failed with 429 Too Many Requests')),
+      429
+    );
+  });
+
+  it('returns undefined for unknown shapes', () => {
+    assert.strictEqual(extractStatusCode(new Error('boom')), undefined);
+    assert.strictEqual(extractStatusCode(null), undefined);
+  });
+});
+
+describe('extractRetryAfterMs', () => {
+  it('reads numeric seconds from headers', () => {
+    assert.strictEqual(
+      extractRetryAfterMs({ headers: { 'retry-after': 2 } }),
+      2000
+    );
+  });
+
+  it('reads string seconds from headers', () => {
+    assert.strictEqual(
+      extractRetryAfterMs({ headers: { 'Retry-After': '3' } }),
+      3000
+    );
+  });
+
+  it('reads retryAfter from response.headers', () => {
+    assert.strictEqual(
+      extractRetryAfterMs({ response: { headers: { 'retry-after': '1' } } }),
+      1000
+    );
+  });
+
+  it('returns undefined when absent', () => {
+    assert.strictEqual(extractRetryAfterMs(new Error('no header')), undefined);
+  });
+});
+
+describe('isRetryableStatus', () => {
+  it('retries on 429 / 502 / 503 / 504', () => {
+    for (const c of [429, 502, 503, 504]) {
+      assert.strictEqual(isRetryableStatus(c), true, `expected ${c} retryable`);
+    }
+  });
+
+  it('does not retry on 4xx (non-429) or 5xx non-listed', () => {
+    for (const c of [400, 401, 403, 404, 409, 422, 500, 501]) {
+      assert.strictEqual(isRetryableStatus(c), false, `expected ${c} non-retryable`);
+    }
+  });
+
+  it('does not retry when status is undefined', () => {
+    assert.strictEqual(isRetryableStatus(undefined), false);
+  });
+});
+
+describe('computeBackoffMs', () => {
+  it('caps at maxDelayMs', () => {
+    // rng=1 → full-cap
+    const result = computeBackoffMs(10, 500, 2000, () => 0.9999);
+    assert.ok(result < 2000, `got ${result}`);
+    assert.ok(result >= 1000, `got ${result}`);
+  });
+
+  it('uses exponential growth before cap', () => {
+    // rng=1 → ceiling, deterministic
+    const a0 = computeBackoffMs(0, 500, 10_000, () => 0.9999);
+    const a2 = computeBackoffMs(2, 500, 10_000, () => 0.9999);
+    assert.ok(a2 > a0, `expected ${a2} > ${a0}`);
+  });
+
+  it('returns 0 when rng returns 0', () => {
+    assert.strictEqual(computeBackoffMs(3, 500, 10_000, () => 0), 0);
+  });
+});
+
+describe('withRetry', () => {
+  // Preserve and clean up env
+  let origDisable: string | undefined;
+  beforeEach(() => {
+    origDisable = process.env.LINEAR_DISABLE_RETRY;
+    delete process.env.LINEAR_DISABLE_RETRY;
+  });
+  afterEach(() => {
+    if (origDisable === undefined) delete process.env.LINEAR_DISABLE_RETRY;
+    else process.env.LINEAR_DISABLE_RETRY = origDisable;
+  });
+
+  it('returns result on first-try success without retrying', async () => {
+    let calls = 0;
+    const result = await withRetry(
+      async () => {
+        calls++;
+        return 'ok';
+      },
+      { sleep: noSleep, log: noLog }
+    );
+    assert.strictEqual(result, 'ok');
+    assert.strictEqual(calls, 1);
+  });
+
+  it('retries on 429 then succeeds', async () => {
+    let calls = 0;
+    const result = await withRetry(
+      async () => {
+        calls++;
+        if (calls === 1) throw makeHttpError(429);
+        return 'recovered';
+      },
+      { sleep: noSleep, log: noLog }
+    );
+    assert.strictEqual(result, 'recovered');
+    assert.strictEqual(calls, 2);
+  });
+
+  it('retries on 503 then succeeds', async () => {
+    let calls = 0;
+    const result = await withRetry(
+      async () => {
+        calls++;
+        if (calls < 3) throw makeHttpError(503);
+        return 'recovered-after-two';
+      },
+      { sleep: noSleep, log: noLog }
+    );
+    assert.strictEqual(calls, 3);
+    assert.strictEqual(result, 'recovered-after-two');
+  });
+
+  it('throws after maxAttempts of retryable errors', async () => {
+    let calls = 0;
+    await assert.rejects(
+      withRetry(
+        async () => {
+          calls++;
+          throw makeHttpError(429);
+        },
+        { maxAttempts: 3, sleep: noSleep, log: noLog }
+      ),
+      /HTTP 429/
+    );
+    assert.strictEqual(calls, 3);
+  });
+
+  it('does not retry on non-retryable errors', async () => {
+    let calls = 0;
+    await assert.rejects(
+      withRetry(
+        async () => {
+          calls++;
+          throw makeHttpError(404);
+        },
+        { sleep: noSleep, log: noLog }
+      ),
+      /HTTP 404/
+    );
+    assert.strictEqual(calls, 1);
+  });
+
+  it('does not retry when error has no status', async () => {
+    let calls = 0;
+    await assert.rejects(
+      withRetry(
+        async () => {
+          calls++;
+          throw new Error('plain failure');
+        },
+        { sleep: noSleep, log: noLog }
+      ),
+      /plain failure/
+    );
+    assert.strictEqual(calls, 1);
+  });
+
+  it('honors Retry-After header when present', async () => {
+    let calls = 0;
+    const sleepCalls: number[] = [];
+    const result = await withRetry(
+      async () => {
+        calls++;
+        if (calls === 1) {
+          throw makeHttpError(429, { headers: { 'retry-after': 2 } });
+        }
+        return 'ok';
+      },
+      {
+        sleep: async (ms: number) => {
+          sleepCalls.push(ms);
+        },
+        log: noLog
+      }
+    );
+    assert.strictEqual(result, 'ok');
+    assert.strictEqual(sleepCalls.length, 1);
+    assert.strictEqual(sleepCalls[0], 2000, `expected 2000ms sleep, got ${sleepCalls[0]}`);
+  });
+
+  it('Retry-After is capped at maxDelayMs', async () => {
+    let calls = 0;
+    const sleepCalls: number[] = [];
+    await withRetry(
+      async () => {
+        calls++;
+        if (calls === 1) {
+          throw makeHttpError(429, { headers: { 'retry-after': 3600 } }); // 1h
+        }
+        return 'ok';
+      },
+      {
+        maxDelayMs: 5000,
+        sleep: async (ms: number) => {
+          sleepCalls.push(ms);
+        },
+        log: noLog
+      }
+    );
+    assert.strictEqual(sleepCalls[0], 5000);
+  });
+
+  it('LINEAR_DISABLE_RETRY=1 bypasses retry logic', async () => {
+    process.env.LINEAR_DISABLE_RETRY = '1';
+    let calls = 0;
+    await assert.rejects(
+      withRetry(
+        async () => {
+          calls++;
+          throw makeHttpError(429);
+        },
+        { sleep: noSleep, log: noLog }
+      ),
+      /HTTP 429/
+    );
+    assert.strictEqual(calls, 1, 'should not retry when kill switch is set');
+  });
+
+  it('emits a log line for each retry attempt', async () => {
+    const logs: string[] = [];
+    let calls = 0;
+    await withRetry(
+      async () => {
+        calls++;
+        if (calls < 3) throw makeHttpError(429);
+        return 'done';
+      },
+      {
+        sleep: noSleep,
+        log: (msg: string) => logs.push(msg)
+      }
+    );
+    assert.strictEqual(logs.length, 2);
+    for (const l of logs) {
+      assert.match(l, /\[retry:linear\] attempt \d+\/\d+ after \d+ms — 429/);
+    }
+  });
+
+  it('log message includes custom label', async () => {
+    const logs: string[] = [];
+    await withRetry(
+      async () => {
+        throw makeHttpError(503);
+      },
+      {
+        maxAttempts: 2,
+        label: 'custom-op',
+        sleep: noSleep,
+        log: (msg: string) => logs.push(msg)
+      }
+    ).catch(() => {});
+    assert.ok(
+      logs[0]?.includes('[retry:custom-op]'),
+      `expected custom label in log, got: ${logs[0]}`
+    );
+  });
+});

--- a/scripts/lib/index.ts
+++ b/scripts/lib/index.ts
@@ -142,3 +142,14 @@ export {
   type IssueConfig,
   type CreateResult
 } from './project-template'
+
+// Retry helper
+export {
+  withRetry,
+  extractStatusCode,
+  extractRetryAfterMs,
+  isRetryableStatus,
+  isRetryDisabled,
+  computeBackoffMs,
+  type RetryOptions
+} from './retry'

--- a/scripts/lib/labels.ts
+++ b/scripts/lib/labels.ts
@@ -6,6 +6,7 @@
  * Integrates with the domain-based label taxonomy.
  */
 import { getLinearClient } from './linear-utils'
+import { withRetry } from './retry'
 import { buildColorMap } from './taxonomy-data'
 import { validateLabels, type ValidationResult } from './taxonomy-validation'
 
@@ -39,8 +40,12 @@ const LABEL_COLORS: Record<string, string> = {
  * Get all existing labels for a team (case-insensitive map)
  */
 export async function getLabelMap(teamId?: string): Promise<Map<string, string>> {
-  const labelsResult = await getLinearClient().issueLabels(
-    teamId ? { filter: { team: { id: { eq: teamId } } } } : undefined
+  const labelsResult = await withRetry(
+    () =>
+      getLinearClient().issueLabels(
+        teamId ? { filter: { team: { id: { eq: teamId } } } } : undefined
+      ),
+    { label: 'getLabelMap' }
   )
 
   const labelMap = new Map<string, string>()
@@ -122,11 +127,15 @@ export async function ensureLabelsExist(
     }
 
     try {
-      const result = await getLinearClient().createIssueLabel({
-        teamId,
-        name,
-        color: LABEL_COLORS[key] || '#6B7280'
-      })
+      const result = await withRetry(
+        () =>
+          getLinearClient().createIssueLabel({
+            teamId,
+            name,
+            color: LABEL_COLORS[key] || '#6B7280'
+          }),
+        { label: `createIssueLabel:${name}` }
+      )
       const label = await result.issueLabel
       if (label) {
         labelMap.set(key, label.id)

--- a/scripts/lib/retry.ts
+++ b/scripts/lib/retry.ts
@@ -1,0 +1,169 @@
+/**
+ * Retry helper for transient Linear API failures.
+ *
+ * Wraps an async function with exponential backoff + jitter for 429 and 5xx
+ * responses. Everything else re-throws immediately so real bugs aren't masked.
+ *
+ * Kill switch: LINEAR_DISABLE_RETRY=1 disables all retrying.
+ */
+
+export interface RetryOptions {
+  /** Max attempts including the first call. Default 4. */
+  maxAttempts?: number
+  /** Initial backoff in ms. Default 500. */
+  baseDelayMs?: number
+  /** Cap on a single backoff delay in ms. Default 8000. */
+  maxDelayMs?: number
+  /** Label used in log output. Default 'linear'. */
+  label?: string
+  /** Injectable sleep for tests. Defaults to setTimeout. */
+  sleep?: (ms: number) => Promise<void>
+  /** Injectable logger. Defaults to console.warn. */
+  log?: (msg: string) => void
+}
+
+const DEFAULTS = {
+  maxAttempts: 4,
+  baseDelayMs: 500,
+  maxDelayMs: 8000,
+  label: 'linear'
+}
+
+const defaultSleep = (ms: number) =>
+  new Promise<void>(resolve => setTimeout(resolve, ms))
+
+/**
+ * Extract an HTTP-like status code from an SDK or fetch error. Returns
+ * undefined if none can be found — callers treat that as non-retryable.
+ */
+export function extractStatusCode(err: unknown): number | undefined {
+  if (!err || typeof err !== 'object') return undefined
+  const e = err as Record<string, unknown>
+
+  for (const key of ['status', 'statusCode']) {
+    const v = e[key]
+    if (typeof v === 'number') return v
+  }
+
+  const resp = e.response
+  if (resp && typeof resp === 'object') {
+    const v = (resp as Record<string, unknown>).status
+    if (typeof v === 'number') return v
+  }
+
+  const msg = typeof e.message === 'string' ? e.message : ''
+  const m = msg.match(/\b(429|500|502|503|504)\b/)
+  if (m) return Number(m[1])
+
+  return undefined
+}
+
+/**
+ * Extract a Retry-After delay (ms) from an error, if the server sent one.
+ * Supports both numeric seconds and HTTP-date values.
+ */
+export function extractRetryAfterMs(err: unknown): number | undefined {
+  if (!err || typeof err !== 'object') return undefined
+  const e = err as Record<string, unknown>
+
+  const headers =
+    (e.headers as Record<string, unknown> | undefined) ??
+    ((e.response as Record<string, unknown> | undefined)?.headers as
+      | Record<string, unknown>
+      | undefined)
+
+  const raw =
+    (headers && (headers['retry-after'] ?? headers['Retry-After'])) ??
+    e.retryAfter ??
+    e['retry-after']
+
+  if (raw == null) return undefined
+
+  if (typeof raw === 'number') return Math.max(0, raw * 1000)
+
+  if (typeof raw === 'string') {
+    const asNum = Number(raw)
+    if (!Number.isNaN(asNum)) return Math.max(0, asNum * 1000)
+    const asDate = Date.parse(raw)
+    if (!Number.isNaN(asDate)) return Math.max(0, asDate - Date.now())
+  }
+
+  return undefined
+}
+
+export function isRetryableStatus(code: number | undefined): boolean {
+  if (code === undefined) return false
+  return code === 429 || code === 502 || code === 503 || code === 504
+}
+
+export function isRetryDisabled(): boolean {
+  return process.env.LINEAR_DISABLE_RETRY === '1'
+}
+
+/**
+ * Compute backoff with full jitter: random in [0, min(maxDelay, base * 2^n)].
+ */
+export function computeBackoffMs(
+  attempt: number,
+  baseDelayMs: number,
+  maxDelayMs: number,
+  rng: () => number = Math.random
+): number {
+  const exp = baseDelayMs * Math.pow(2, attempt)
+  const capped = Math.min(maxDelayMs, exp)
+  return Math.floor(rng() * capped)
+}
+
+/**
+ * Run `fn`, retrying on 429 / 5xx. Non-retryable errors bubble up immediately.
+ *
+ * @example
+ *   const labels = await withRetry(() => client.issueLabels(), { label: 'labels' })
+ */
+export async function withRetry<T>(
+  fn: () => Promise<T>,
+  opts: RetryOptions = {}
+): Promise<T> {
+  if (isRetryDisabled()) {
+    return fn()
+  }
+
+  const maxAttempts = opts.maxAttempts ?? DEFAULTS.maxAttempts
+  const baseDelayMs = opts.baseDelayMs ?? DEFAULTS.baseDelayMs
+  const maxDelayMs = opts.maxDelayMs ?? DEFAULTS.maxDelayMs
+  const label = opts.label ?? DEFAULTS.label
+  const sleep = opts.sleep ?? defaultSleep
+  const log = opts.log ?? ((msg: string) => console.warn(msg))
+
+  let lastErr: unknown
+
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    try {
+      return await fn()
+    } catch (err) {
+      lastErr = err
+      const status = extractStatusCode(err)
+      const isLast = attempt === maxAttempts - 1
+
+      if (!isRetryableStatus(status) || isLast) {
+        throw err
+      }
+
+      const retryAfter = extractRetryAfterMs(err)
+      const backoff =
+        retryAfter !== undefined
+          ? Math.min(retryAfter, maxDelayMs)
+          : computeBackoffMs(attempt, baseDelayMs, maxDelayMs)
+
+      log(
+        `[retry:${label}] attempt ${attempt + 1}/${maxAttempts} after ${backoff}ms — ${status}${
+          retryAfter !== undefined ? ' (Retry-After honored)' : ''
+        }`
+      )
+
+      await sleep(backoff)
+    }
+  }
+
+  throw lastErr
+}


### PR DESCRIPTION
## Summary
- New `withRetry()` helper in `scripts/lib/retry.ts` — exponential backoff + full jitter, retries on 429 / 502 / 503 / 504, honors `Retry-After`, `LINEAR_DISABLE_RETRY=1` kill switch.
- `getLabelMap()` and the `createIssueLabel` call inside `ensureLabelsExist()` now route through `withRetry()`. No caller-visible signature changes.
- 17 unit tests in `scripts/__tests__/retry.test.ts` covering first-try success, retry-then-success (429 and 503), exhaustion, non-retryable pass-through (4xx non-429, plain errors), `Retry-After` honored + capped, kill-switch bypass, and log-line shape.

Closes SMI-4346.

## Test plan
- [x] `npm run build` clean
- [x] `npm test` — 75/75 pass (17 new retry tests + all prior tests)
- [ ] CI green on this PR
- [ ] Manual smoke on next batch create-issue call after merge (first real run should show no change; 429 path is mocked-only until we hit one in the wild)

## Notes
- Retry wrapping of *every* Linear SDK call (issue create, project create, comment, etc.) is intentionally out of scope — follow-up once the helper has proven itself on labels.
- `feat:` prefix → minor version bump on merge.

🤖 Generated with [Ruflo](https://github.com/ruvnet/ruflo)