### PR TITLE
fix(linear-ops): handle lin >=2026.x wrapped JSON in whoami/search/initiatives

### DIFF
--- a/scripts/linear-ops.ts
+++ b/scripts/linear-ops.ts
@@ -1790,7 +1790,17 @@ const commands: Record<string, (...args: string[]) => Promise<void>> = {
     if (state) linArgs.push('--state', state);
 
     await tryLin(linArgs, sdkListIssues, (data: unknown) => {
-      const issues = Array.isArray(data) ? data : [];
+      // lin >=2026.x wraps as { issues: [...] } or { issues: { nodes: [...] } }; older lin returned a bare array.
+      const root = data as Record<string, unknown>;
+      const wrapped = root.issues;
+      const nested = Array.isArray(wrapped) ? undefined : (wrapped as Record<string, unknown> | undefined)?.nodes;
+      const issues = Array.isArray(data)
+        ? data
+        : Array.isArray(wrapped)
+          ? wrapped
+          : Array.isArray(nested)
+            ? nested
+            : [];
       if (issues.length === 0) {
         console.log('No issues found.');
         return;

--- a/scripts/linear-ops.ts
+++ b/scripts/linear-ops.ts
@@ -58,6 +58,23 @@ import {
   isStrictMode
 } from './lib';
 
+// lin >=2026.x wraps `--json` output in container objects (e.g. { issues: [...] } or
+// { initiatives: { nodes: [...] } }); older lin returned flatter shapes (bare arrays / flat
+// objects). These helpers unwrap either, and stay null-safe if `lin` ever emits a bare `null`.
+function unwrapLinList(data: unknown, key: string): unknown[] {
+  if (Array.isArray(data)) return data;
+  const wrapped = (data as Record<string, unknown> | null)?.[key];
+  if (Array.isArray(wrapped)) return wrapped;
+  const nested = (wrapped as Record<string, unknown> | undefined)?.nodes;
+  return Array.isArray(nested) ? nested : [];
+}
+
+function unwrapLinObject(data: unknown, key: string): Record<string, unknown> {
+  const root = (data as Record<string, unknown> | null) ?? {};
+  const wrapped = root[key];
+  return typeof wrapped === 'object' && wrapped !== null ? (wrapped as Record<string, unknown>) : root;
+}
+
 // Lazy API key validation and client creation
 // Commands that don't need the API (help, labels taxonomy/validate/suggest/agents/matrix)
 // can run without LINEAR_API_KEY being set.
@@ -924,10 +941,7 @@ const commands: Record<string, (...args: string[]) => Promise<void>> = {
     };
 
     await tryLin(['initiatives', 'list'], sdkListInitiatives, (data: unknown) => {
-      // lin >=2026.x wraps as { initiatives: { nodes: [...] } }; older lin returned a bare array.
-      const root = data as Record<string, unknown>;
-      const wrapped = (root.initiatives as Record<string, unknown>)?.nodes;
-      const initiatives = Array.isArray(data) ? data : Array.isArray(wrapped) ? wrapped : [];
+      const initiatives = unwrapLinList(data, 'initiatives');
       if (initiatives.length === 0) {
         console.log('No initiatives found.');
         return;
@@ -1021,9 +1035,7 @@ const commands: Record<string, (...args: string[]) => Promise<void>> = {
 
     await tryLin(['me'], sdkWhoami, (data: unknown) => {
       // Format lin JSON output to match existing display.
-      // lin >=2026.x wraps under `viewer`; older lin returned the user flat. Support both.
-      const root = data as Record<string, unknown>;
-      const user = (root.viewer as Record<string, unknown>) ?? root;
+      const user = unwrapLinObject(data, 'viewer');
       console.log('Current User:');
       console.log(`  Name:  ${user.name || user.displayName || 'Unknown'}`);
       console.log(`  Email: ${user.email || 'Unknown'}`);
@@ -1037,12 +1049,9 @@ const commands: Record<string, (...args: string[]) => Promise<void>> = {
         console.log('');
       }
       // Teams: legacy `teams` array, or current `teamMemberships.nodes[].team`.
-      const memberships = user.teamMemberships as Record<string, unknown> | undefined;
       const teamList: unknown[] = Array.isArray(user.teams)
         ? user.teams
-        : Array.isArray(memberships?.nodes)
-          ? (memberships.nodes as unknown[]).map((m) => (m as Record<string, unknown>).team)
-          : [];
+        : unwrapLinList(user, 'teamMemberships').map((m) => (m as Record<string, unknown>).team);
       if (teamList.length > 0) {
         console.log('Teams:');
         for (const team of teamList) {
@@ -1729,9 +1738,7 @@ const commands: Record<string, (...args: string[]) => Promise<void>> = {
     };
 
     await tryLin(['search', query], sdkSearch, (data: unknown) => {
-      // lin >=2026.x wraps as { documents: [...], issues: [...] }; older lin returned a bare array.
-      const root = data as Record<string, unknown>;
-      const issues = Array.isArray(data) ? data : Array.isArray(root.issues) ? root.issues : [];
+      const issues = unwrapLinList(data, 'issues');
       if (issues.length === 0) {
         console.log('No results found.');
         return;
@@ -1790,17 +1797,7 @@ const commands: Record<string, (...args: string[]) => Promise<void>> = {
     if (state) linArgs.push('--state', state);
 
     await tryLin(linArgs, sdkListIssues, (data: unknown) => {
-      // lin >=2026.x wraps as { issues: [...] } or { issues: { nodes: [...] } }; older lin returned a bare array.
-      const root = data as Record<string, unknown>;
-      const wrapped = root.issues;
-      const nested = Array.isArray(wrapped) ? undefined : (wrapped as Record<string, unknown> | undefined)?.nodes;
-      const issues = Array.isArray(data)
-        ? data
-        : Array.isArray(wrapped)
-          ? wrapped
-          : Array.isArray(nested)
-            ? nested
-            : [];
+      const issues = unwrapLinList(data, 'issues');
       if (issues.length === 0) {
         console.log('No issues found.');
         return;

--- a/scripts/linear-ops.ts
+++ b/scripts/linear-ops.ts
@@ -924,7 +924,10 @@ const commands: Record<string, (...args: string[]) => Promise<void>> = {
     };
 
     await tryLin(['initiatives', 'list'], sdkListInitiatives, (data: unknown) => {
-      const initiatives = Array.isArray(data) ? data : [];
+      // lin >=2026.x wraps as { initiatives: { nodes: [...] } }; older lin returned a bare array.
+      const root = data as Record<string, unknown>;
+      const wrapped = (root.initiatives as Record<string, unknown>)?.nodes;
+      const initiatives = Array.isArray(data) ? data : Array.isArray(wrapped) ? wrapped : [];
       if (initiatives.length === 0) {
         console.log('No initiatives found.');
         return;
@@ -1017,10 +1020,12 @@ const commands: Record<string, (...args: string[]) => Promise<void>> = {
     };
 
     await tryLin(['me'], sdkWhoami, (data: unknown) => {
-      // Format lin JSON output to match existing display
-      const user = data as Record<string, unknown>;
+      // Format lin JSON output to match existing display.
+      // lin >=2026.x wraps under `viewer`; older lin returned the user flat. Support both.
+      const root = data as Record<string, unknown>;
+      const user = (root.viewer as Record<string, unknown>) ?? root;
       console.log('Current User:');
-      console.log(`  Name:  ${user.name || 'Unknown'}`);
+      console.log(`  Name:  ${user.name || user.displayName || 'Unknown'}`);
       console.log(`  Email: ${user.email || 'Unknown'}`);
       console.log(`  ID:    ${user.id || 'Unknown'}`);
       console.log('');
@@ -1031,9 +1036,16 @@ const commands: Record<string, (...args: string[]) => Promise<void>> = {
         console.log(`  ID:   ${org.id || 'Unknown'}`);
         console.log('');
       }
-      if (Array.isArray(user.teams)) {
+      // Teams: legacy `teams` array, or current `teamMemberships.nodes[].team`.
+      const memberships = user.teamMemberships as Record<string, unknown> | undefined;
+      const teamList: unknown[] = Array.isArray(user.teams)
+        ? user.teams
+        : Array.isArray(memberships?.nodes)
+          ? (memberships.nodes as unknown[]).map((m) => (m as Record<string, unknown>).team)
+          : [];
+      if (teamList.length > 0) {
         console.log('Teams:');
-        for (const team of user.teams) {
+        for (const team of teamList) {
           const t = team as Record<string, unknown>;
           console.log(`  - ${t.name} (${t.key})`);
         }
@@ -1717,7 +1729,9 @@ const commands: Record<string, (...args: string[]) => Promise<void>> = {
     };
 
     await tryLin(['search', query], sdkSearch, (data: unknown) => {
-      const issues = Array.isArray(data) ? data : [];
+      // lin >=2026.x wraps as { documents: [...], issues: [...] }; older lin returned a bare array.
+      const root = data as Record<string, unknown>;
+      const issues = Array.isArray(data) ? data : Array.isArray(root.issues) ? root.issues : [];
       if (issues.length === 0) {
         console.log('No results found.');
         return;


### PR DESCRIPTION
## Problem

The `lin` CLI ([aaronkwhite/linear-cli](https://github.com/aaronkwhite/linear-cli)) v2026.x wraps its `--json` output in a container object, whereas earlier versions returned flatter shapes:

| command | current `lin` (2026.5.5) output |
|---|---|
| `lin me` | `{ viewer: { name, email, id, organization, teamMemberships: { nodes: [{ team }] } } }` |
| `lin initiatives list` | `{ initiatives: { nodes: [...] } }` |
| `lin search <q>` | `{ documents: [...], issues: [...] }` |

The three `tryLin` formatters in `scripts/linear-ops.ts` assumed the older shapes (a flat user object and bare arrays). Because `lin` is present and returns success, the SDK fallback is bypassed — so against current `lin`:

- `whoami` prints `Unknown` for **every** field (name, email, id, org, teams)
- `search` and `initiatives list` silently report **"No results found"** even when matches exist

This is easy to miss because the SDK path (no `lin` installed) still works — the bug only appears once a user follows the README's optional `lin` install.

## Fix

Unwrap the new container shapes (`viewer`, `initiatives.nodes`, `issues`, and `teamMemberships.nodes[].team`) while keeping the legacy bare-array / flat-object paths as fallbacks, so **both old and new `lin` releases** work. No behavior change on the SDK path.

## Verification

Against `lin` 2026.5.5 with the build (`npm run build`):

```
$ npm run ops -- whoami
Current User:
  Name:  Chase Saunders
  Email: <redacted>
  ID:    <redacted>
Organization:
  Name: <org>
Teams:
  - <Team> (KEY)

$ npm run ops -- search "PRA"
Found 10 issue(s):
  VER-389  Rebuild to PRA parity ...
  ...
```

Both previously returned `Unknown` / `No results found`. `tsc --noEmit` passes (via `npm run build`).